### PR TITLE
feat: add neutron-fwaas support for OVN firewall service driver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,11 @@ jobs:
 
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@5923a8fba3a98cf17e36583cc498d5e70a01c482 # main
         with:
+          repository: openstack/neutron-fwaas
+          ref: d65605062229992d637157eab06d509daadbda34 # master
+
+      - uses: vexxhost/docker-atmosphere/.github/actions/checkout@main
+        with:
           repository: vexxhost/atmosphere
           ref: main
           path: vexxhost/atmosphere
@@ -83,5 +88,6 @@ jobs:
             neutron-policy-server=vexxhost/neutron-policy-server
             neutron-ovn-network-logging-parser=vexxhost/neutron-ovn-network-logging-parser
             tap-as-a-service=openstack/tap-as-a-service
+            neutron-fwaas=openstack/neutron-fwaas
             ovsinit-src=vexxhost/atmosphere/crates/ovsinit
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,11 @@ jobs:
 
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@5923a8fba3a98cf17e36583cc498d5e70a01c482 # main
         with:
+          repository: openstack/neutron-fwaas
+          ref: d65605062229992d637157eab06d509daadbda34 # master
+
+      - uses: vexxhost/docker-atmosphere/.github/actions/checkout@5923a8fba3a98cf17e36583cc498d5e70a01c482 # main
+        with:
           repository: openstack/neutron-vpnaas
           ref: 574bed1358e668364e3a69a91f249fd65cb11911 # master
 
@@ -65,11 +70,6 @@ jobs:
           repository: openstack/tap-as-a-service
           ref: f7b99350c74a2a561ea366127c490d5a40b6e93d # master
 
-      - uses: vexxhost/docker-atmosphere/.github/actions/checkout@5923a8fba3a98cf17e36583cc498d5e70a01c482 # main
-        with:
-          repository: openstack/neutron-fwaas
-          ref: d65605062229992d637157eab06d509daadbda34 # master
-
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@main
         with:
           repository: vexxhost/atmosphere
@@ -82,12 +82,12 @@ jobs:
           build-contexts: |
             neutron=openstack/neutron
             neutron-dynamic-routing=openstack/neutron-dynamic-routing
+            neutron-fwaas=openstack/neutron-fwaas
             neutron-vpnaas=openstack/neutron-vpnaas
             networking-baremetal=openstack/networking-baremetal
             networking-generic-switch=openstack/networking-generic-switch
             neutron-policy-server=vexxhost/neutron-policy-server
             neutron-ovn-network-logging-parser=vexxhost/neutron-ovn-network-logging-parser
             tap-as-a-service=openstack/tap-as-a-service
-            neutron-fwaas=openstack/neutron-fwaas
             ovsinit-src=vexxhost/atmosphere/crates/ovsinit
           push: ${{ github.event_name != 'pull_request' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN \
   --mount=type=bind,from=networking-generic-switch,source=/,target=/src/networking-generic-switch,readwrite \
   --mount=type=bind,from=neutron-policy-server,source=/,target=/src/neutron-policy-server,readwrite \
   --mount=type=bind,from=neutron-ovn-network-logging-parser,source=/,target=/src/neutron-ovn-network-logging-parser,readwrite \
-  --mount=type=bind,from=tap-as-a-service,source=/,target=/src/tap-as-a-service,readwrite <<EOF bash -xe
+  --mount=type=bind,from=tap-as-a-service,source=/,target=/src/tap-as-a-service,readwrite \
+  --mount=type=bind,from=neutron-fwaas,source=/,target=/src/neutron-fwaas,readwrite <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/neutron \
@@ -26,6 +27,7 @@ uv pip install \
         /src/neutron-policy-server \
         /src/neutron-ovn-network-logging-parser \
         /src/tap-as-a-service \
+        /src/neutron-fwaas \
         pymemcache
 EOF
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,24 +10,24 @@ FROM ghcr.io/vexxhost/openstack-venv-builder:main@sha256:336ba4260920dd0c401f4c1
 RUN \
   --mount=type=bind,from=neutron,source=/,target=/src/neutron,readwrite \
   --mount=type=bind,from=neutron-dynamic-routing,source=/,target=/src/neutron-dynamic-routing,readwrite \
+  --mount=type=bind,from=neutron-fwaas,source=/,target=/src/neutron-fwaas,readwrite \
   --mount=type=bind,from=neutron-vpnaas,source=/,target=/src/neutron-vpnaas,readwrite \
   --mount=type=bind,from=networking-baremetal,source=/,target=/src/networking-baremetal,readwrite \
   --mount=type=bind,from=networking-generic-switch,source=/,target=/src/networking-generic-switch,readwrite \
   --mount=type=bind,from=neutron-policy-server,source=/,target=/src/neutron-policy-server,readwrite \
   --mount=type=bind,from=neutron-ovn-network-logging-parser,source=/,target=/src/neutron-ovn-network-logging-parser,readwrite \
-  --mount=type=bind,from=tap-as-a-service,source=/,target=/src/tap-as-a-service,readwrite \
-  --mount=type=bind,from=neutron-fwaas,source=/,target=/src/neutron-fwaas,readwrite <<EOF bash -xe
+  --mount=type=bind,from=tap-as-a-service,source=/,target=/src/tap-as-a-service,readwrite <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/neutron \
         /src/neutron-dynamic-routing \
+        /src/neutron-fwaas \
         /src/neutron-vpnaas \
         /src/networking-baremetal \
         /src/networking-generic-switch \
         /src/neutron-policy-server \
         /src/neutron-ovn-network-logging-parser \
         /src/tap-as-a-service \
-        /src/neutron-fwaas \
         pymemcache
 EOF
 


### PR DESCRIPTION
## Summary

Add `neutron-fwaas` package to the Docker image build to enable Firewall as a Service (FWaaS) with OVN network backend support.

## Changes

- **Dockerfile**: Added `neutron-fwaas` as a bind mount source and pip install target
- **CI workflow**: Added checkout of `openstack/neutron-fwaas` (latest master) and build context

## Atmosphere Configuration Required

To use FWaaS with OVN in Atmosphere, the following Neutron config changes are needed:

```ini
# neutron.conf
[DEFAULT]
service_plugins = ...,firewall_v2

# neutron_fwaas.conf
[fwaas]
driver = neutron_fwaas.services.firewall.service_drivers.ovn.firewall_l3_driver.OVNFirewallL3Driver
enabled = True

[service_providers]
service_provider = FIREWALL_V2:fwaas_db:neutron_fwaas.services.firewall.service_drivers.ovn.firewall_l3_driver.OVNFirewallL3Driver:default
```

A `neutron-db-manage upgrade head` is also required after deployment as neutron-fwaas adds its own DB tables.

## References

- OVN FWaaS driver: https://github.com/openstack/neutron-fwaas/tree/master/neutron_fwaas/services/firewall/service_drivers/ovn