### PR TITLE
Bump to stable/2026.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,27 +28,27 @@ jobs:
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@a1ad25c00b6bbf44621748b3a9ed664c6b6cf929 # main
         with:
           repository: openstack/neutron
-          ref: a78b72cacd2b5f3ed4b6f53c79b8c7e97735b117 # master
+          ref: 61f100d4b987a493b9bbf61301caf2ed41e544d2 # stable/2026.1
 
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@a1ad25c00b6bbf44621748b3a9ed664c6b6cf929 # main
         with:
           repository: openstack/neutron-dynamic-routing
-          ref: d20b1f41dbd8213b9f43a8a77c3395122ff1ad29 # master
+          ref: cfa3822a95704f2390c22f38c3e3137c6ad9e1c5 # stable/2026.1
 
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@a1ad25c00b6bbf44621748b3a9ed664c6b6cf929 # main
         with:
           repository: openstack/neutron-vpnaas
-          ref: d4e96b80e18502af9e8833a49a6ffee1b71b8203 # master
+          ref: 261f874756197543419488fe503711559d0e36ca # stable/2026.1
 
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@a1ad25c00b6bbf44621748b3a9ed664c6b6cf929 # main
         with:
           repository: openstack/networking-baremetal
-          ref: 2cd5ca28b9c158baf12ab6fa3891f112809ee9ba # master
+          ref: 35b81c0bae30210d15670cc888ed6e1b3d5ffe89 # stable/2026.1
 
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@a1ad25c00b6bbf44621748b3a9ed664c6b6cf929 # main
         with:
           repository: openstack/networking-generic-switch
-          ref: 053d1243535efc985766b7bdcbabe4954380190f # master
+          ref: abfe422790d5113a284fd81bed61cd69e3fab38b # stable/2026.1
 
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@a1ad25c00b6bbf44621748b3a9ed664c6b6cf929 # main
         with:
@@ -63,7 +63,7 @@ jobs:
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@a1ad25c00b6bbf44621748b3a9ed664c6b6cf929 # main
         with:
           repository: openstack/tap-as-a-service
-          ref: f7b99350c74a2a561ea366127c490d5a40b6e93d # master
+          ref: 0412df213bc8a4aa7f83264c272027d23a5573e5 # stable/2026.1
 
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@a1ad25c00b6bbf44621748b3a9ed664c6b6cf929 # main
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /src
 COPY --from=ovsinit-src / /src
 RUN cargo install --path .
 
-FROM ghcr.io/vexxhost/openstack-venv-builder:main@sha256:c8e3b9b85b78bf65aa9d43653ce24600161b952b62460c53bca55f7212ceb739 AS build
+FROM ghcr.io/vexxhost/openstack-venv-builder:2026.1@sha256:4d8390ccb715010a3504200f47405318309c4ba48ac0010d2b2a0764a73cc7de AS build
 RUN \
   --mount=type=bind,from=neutron,source=/,target=/src/neutron,readwrite \
   --mount=type=bind,from=neutron-dynamic-routing,source=/,target=/src/neutron-dynamic-routing,readwrite \
@@ -29,7 +29,7 @@ uv pip install \
         pymemcache
 EOF
 
-FROM ghcr.io/vexxhost/python-base:main@sha256:95dce35dcbda1eaaa303ab47d76869728de278d64cbbdebd42b8de2330347751
+FROM ghcr.io/vexxhost/python-base:2026.1@sha256:a570b4c94c85b6359733def197eae3eb0f15818629c2d6b42a7cbb1a885325b5
 RUN \
     groupadd -g 42424 neutron && \
     useradd -u 42424 -g 42424 -M -d /var/lib/neutron -s /usr/sbin/nologin -c "Neutron User" neutron && \


### PR DESCRIPTION
Automated bump of base image digests and upstream refs to stable/2026.1.

- Dockerfile: openstack-venv-builder: main -> 2026.1
- Dockerfile: python-base: main -> 2026.1
- build.yml: openstack/neutron: master -> stable/2026.1
- build.yml: openstack/neutron-dynamic-routing: master -> stable/2026.1
- build.yml: openstack/neutron-vpnaas: master -> stable/2026.1
- build.yml: openstack/networking-baremetal: master -> stable/2026.1
- build.yml: openstack/networking-generic-switch: master -> stable/2026.1
- build.yml: openstack/tap-as-a-service: master -> stable/2026.1