### PR TITLE
ci: add OpenStack tox validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   tox:
     name: tox (${{ matrix.project.repository }})
-    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@d763fd8920390074628431db771a56ab4f7aa8e2 # main
+    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@5923a8fba3a98cf17e36583cc498d5e70a01c482 # main
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   tox:
     name: tox (${{ matrix.project.repository }})
-    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@2244615e3b5ef56a6e83e993ede50ea9c3716cd7 # main
+    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@2bed598442494c60f1f9ae004626473f7c400bf7 # main
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   tox:
     name: tox (${{ matrix.project.repository }})
-    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@2bed598442494c60f1f9ae004626473f7c400bf7 # main
+    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@d763fd8920390074628431db771a56ab4f7aa8e2 # main
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   tox:
     name: tox (${{ matrix.project.repository }})
-    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@0dcf370eb08b3f884992181348b8c41d7f66c10e # main
+    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@2244615e3b5ef56a6e83e993ede50ea9c3716cd7 # main
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,29 @@ permissions:
   contents: read
 
 jobs:
+  tox:
+    name: tox (${{ matrix.project.repository }})
+    uses: vexxhost/docker-atmosphere/.github/workflows/tox.yml@0dcf370eb08b3f884992181348b8c41d7f66c10e # main
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - repository: openstack/neutron
+            ref: 9925d26bc22397cb1e6e87d7417b7f753ca2245a # master
+          - repository: openstack/neutron-dynamic-routing
+            ref: 5f608f7d3d43396cb956241e4ae2d5759bfb126d # master
+          - repository: openstack/neutron-vpnaas
+            ref: 574bed1358e668364e3a69a91f249fd65cb11911 # master
+          - repository: openstack/networking-baremetal
+            ref: f327f9118240efd606890bce1dc6e9690749b860 # master
+          - repository: openstack/networking-generic-switch
+            ref: 053d1243535efc985766b7bdcbabe4954380190f # master
+          - repository: openstack/tap-as-a-service
+            ref: f7b99350c74a2a561ea366127c490d5a40b6e93d # master
+    with:
+      repository: ${{ matrix.project.repository }}
+      ref: ${{ matrix.project.ref }}
+
   image:
     runs-on: ubuntu-latest
     permissions:

--- a/patches/openstack/neutron/0002-fix-ha-chassis-group.patch
+++ b/patches/openstack/neutron/0002-fix-ha-chassis-group.patch
@@ -44,15 +44,7 @@ diff --git a/neutron/tests/unit/services/ovn_l3/test_plugin.py b/neutron/tests/u
 index c9b1e85..94271588 100644
 --- a/neutron/tests/unit/services/ovn_l3/test_plugin.py
 +++ b/neutron/tests/unit/services/ovn_l3/test_plugin.py
-@@ -13,6 +13,7 @@
- #
- 
- import copy
-+import uuid
- from unittest import mock
- 
- from neutron_lib.api.definitions import external_net
-@@ -761,8 +762,11 @@
+@@ -761,8 +761,11 @@
      @mock.patch('neutron.plugins.ml2.drivers.ovn.mech_driver.ovsdb.ovn_client'
                  '.OVNClient._get_router_ports')
      @mock.patch('neutron.db.l3_db.L3_NAT_dbonly_mixin.add_router_interface')
@@ -60,12 +52,12 @@ index c9b1e85..94271588 100644
 +    @mock.patch('neutron.common.ovn.utils.sync_ha_chassis_group_network')
 +    def test_add_router_interface_vlan_network(self, shcg, ari, grps, gn):
          router_id = 'router-id'
-+        ha_chassis_group_uuid = uuid.uuid4()
++        ha_chassis_group_uuid = uuidutils.generate_uuid()
 +        shcg.return_value = (ha_chassis_group_uuid, "fake_ha_chassis_group")
          ari.return_value = self.fake_router_interface_info
          self.get_router.return_value = self.fake_router_with_ext_gw
  
-@@ -787,6 +791,7 @@
+@@ -787,6 +790,7 @@
          fake_router_port_assert = self.fake_router_port_assert
          fake_router_port_assert['options'] = {
              'reside-on-redirect-chassis': 'true'}
@@ -73,7 +65,7 @@ index c9b1e85..94271588 100644
  
          self.l3_inst._nb_ovn.add_lrouter_port.assert_called_once_with(
              **fake_router_port_assert)
-@@ -798,6 +803,7 @@
+@@ -798,6 +802,7 @@
              'neutron-router-id', logical_ip='10.0.0.0/24',
              external_ip='192.168.1.1', type='snat')
  


### PR DESCRIPTION
## Summary
- add the shared docker-atmosphere tox reusable workflow to the build workflow
- test only the existing openstack/ checkout targets used by the image build
- keep each tox ref pinned to the same commit currently used by the image checkout
- set caller-level `fail-fast: false` so multi-project matrices report every OpenStack tox result

## Testing
- `nix-shell -p actionlint --run "actionlint .github/workflows/build.yml"`
- GitHub Actions tox checks were allowed to complete on this PR