### PR TITLE
feat: add neutron-fwaas support for OVN firewall service driver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,11 @@ jobs:
 
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@5923a8fba3a98cf17e36583cc498d5e70a01c482 # main
         with:
+          repository: openstack/neutron-fwaas
+          ref: a356af56940d8d12ccbc05f64d2268fb3ff3550c # stable/2026.1
+
+      - uses: vexxhost/docker-atmosphere/.github/actions/checkout@main
+        with:
           repository: vexxhost/atmosphere
           ref: main
           path: vexxhost/atmosphere
@@ -83,5 +88,6 @@ jobs:
             neutron-policy-server=vexxhost/neutron-policy-server
             neutron-ovn-network-logging-parser=vexxhost/neutron-ovn-network-logging-parser
             tap-as-a-service=openstack/tap-as-a-service
+            neutron-fwaas=openstack/neutron-fwaas
             ovsinit-src=vexxhost/atmosphere/crates/ovsinit
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,11 @@ jobs:
 
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@5923a8fba3a98cf17e36583cc498d5e70a01c482 # main
         with:
+          repository: openstack/neutron-fwaas
+          ref: a356af56940d8d12ccbc05f64d2268fb3ff3550c # stable/2026.1
+
+      - uses: vexxhost/docker-atmosphere/.github/actions/checkout@5923a8fba3a98cf17e36583cc498d5e70a01c482 # main
+        with:
           repository: openstack/neutron-vpnaas
           ref: 261f874756197543419488fe503711559d0e36ca # stable/2026.1
 
@@ -65,11 +70,6 @@ jobs:
           repository: openstack/tap-as-a-service
           ref: 0412df213bc8a4aa7f83264c272027d23a5573e5 # stable/2026.1
 
-      - uses: vexxhost/docker-atmosphere/.github/actions/checkout@5923a8fba3a98cf17e36583cc498d5e70a01c482 # main
-        with:
-          repository: openstack/neutron-fwaas
-          ref: a356af56940d8d12ccbc05f64d2268fb3ff3550c # stable/2026.1
-
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@main
         with:
           repository: vexxhost/atmosphere
@@ -82,12 +82,12 @@ jobs:
           build-contexts: |
             neutron=openstack/neutron
             neutron-dynamic-routing=openstack/neutron-dynamic-routing
+            neutron-fwaas=openstack/neutron-fwaas
             neutron-vpnaas=openstack/neutron-vpnaas
             networking-baremetal=openstack/networking-baremetal
             networking-generic-switch=openstack/networking-generic-switch
             neutron-policy-server=vexxhost/neutron-policy-server
             neutron-ovn-network-logging-parser=vexxhost/neutron-ovn-network-logging-parser
             tap-as-a-service=openstack/tap-as-a-service
-            neutron-fwaas=openstack/neutron-fwaas
             ovsinit-src=vexxhost/atmosphere/crates/ovsinit
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
           repository: openstack/tap-as-a-service
           ref: 0412df213bc8a4aa7f83264c272027d23a5573e5 # stable/2026.1
 
-      - uses: vexxhost/docker-atmosphere/.github/actions/checkout@main
+      - uses: vexxhost/docker-atmosphere/.github/actions/checkout@5923a8fba3a98cf17e36583cc498d5e70a01c482 # main
         with:
           repository: vexxhost/atmosphere
           ref: main

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN \
   --mount=type=bind,from=networking-generic-switch,source=/,target=/src/networking-generic-switch,readwrite \
   --mount=type=bind,from=neutron-policy-server,source=/,target=/src/neutron-policy-server,readwrite \
   --mount=type=bind,from=neutron-ovn-network-logging-parser,source=/,target=/src/neutron-ovn-network-logging-parser,readwrite \
-  --mount=type=bind,from=tap-as-a-service,source=/,target=/src/tap-as-a-service,readwrite <<EOF bash -xe
+  --mount=type=bind,from=tap-as-a-service,source=/,target=/src/tap-as-a-service,readwrite \
+  --mount=type=bind,from=neutron-fwaas,source=/,target=/src/neutron-fwaas,readwrite <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/neutron \
@@ -26,6 +27,7 @@ uv pip install \
         /src/neutron-policy-server \
         /src/neutron-ovn-network-logging-parser \
         /src/tap-as-a-service \
+        /src/neutron-fwaas \
         pymemcache
 EOF
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,24 +10,24 @@ FROM ghcr.io/vexxhost/openstack-venv-builder:2026.1@sha256:659c67995c0c06c1d16a0
 RUN \
   --mount=type=bind,from=neutron,source=/,target=/src/neutron,readwrite \
   --mount=type=bind,from=neutron-dynamic-routing,source=/,target=/src/neutron-dynamic-routing,readwrite \
+  --mount=type=bind,from=neutron-fwaas,source=/,target=/src/neutron-fwaas,readwrite \
   --mount=type=bind,from=neutron-vpnaas,source=/,target=/src/neutron-vpnaas,readwrite \
   --mount=type=bind,from=networking-baremetal,source=/,target=/src/networking-baremetal,readwrite \
   --mount=type=bind,from=networking-generic-switch,source=/,target=/src/networking-generic-switch,readwrite \
   --mount=type=bind,from=neutron-policy-server,source=/,target=/src/neutron-policy-server,readwrite \
   --mount=type=bind,from=neutron-ovn-network-logging-parser,source=/,target=/src/neutron-ovn-network-logging-parser,readwrite \
-  --mount=type=bind,from=tap-as-a-service,source=/,target=/src/tap-as-a-service,readwrite \
-  --mount=type=bind,from=neutron-fwaas,source=/,target=/src/neutron-fwaas,readwrite <<EOF bash -xe
+  --mount=type=bind,from=tap-as-a-service,source=/,target=/src/tap-as-a-service,readwrite <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/neutron \
         /src/neutron-dynamic-routing \
+        /src/neutron-fwaas \
         /src/neutron-vpnaas \
         /src/networking-baremetal \
         /src/networking-generic-switch \
         /src/neutron-policy-server \
         /src/neutron-ovn-network-logging-parser \
         /src/tap-as-a-service \
-        /src/neutron-fwaas \
         pymemcache
 EOF
 


### PR DESCRIPTION
Add neutron-fwaas package to the Docker image build to enable Firewall as a Service (FWaaS) with OVN network backend support.



(cherry picked from commit f91bb5cfc70adc50b4577418602e1daa3af01531)