### PR TITLE
feat: add neutron-fwaas support for OVN firewall service driver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,11 @@ jobs:
 
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@5923a8fba3a98cf17e36583cc498d5e70a01c482 # main
         with:
+          repository: openstack/neutron-fwaas
+          ref: f6a36133a788697712733a69f10999fc2a9e2d6f # stable/2025.2
+
+      - uses: vexxhost/docker-atmosphere/.github/actions/checkout@main
+        with:
           repository: vexxhost/atmosphere
           ref: stable/2025.2
           path: vexxhost/atmosphere
@@ -75,5 +80,6 @@ jobs:
             neutron-policy-server=vexxhost/neutron-policy-server
             neutron-ovn-network-logging-parser=vexxhost/neutron-ovn-network-logging-parser
             tap-as-a-service=openstack/tap-as-a-service
+            neutron-fwaas=openstack/neutron-fwaas
             ovsinit-src=vexxhost/atmosphere/crates/ovsinit
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
           repository: openstack/tap-as-a-service
           ref: 7b413b43f2cedb0a43056c4d6f89d413448050b2 # stable/2025.2
 
-      - uses: vexxhost/docker-atmosphere/.github/actions/checkout@main
+      - uses: vexxhost/docker-atmosphere/.github/actions/checkout@5923a8fba3a98cf17e36583cc498d5e70a01c482 # main
         with:
           repository: vexxhost/atmosphere
           ref: stable/2025.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,11 @@ jobs:
 
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@5923a8fba3a98cf17e36583cc498d5e70a01c482 # main
         with:
+          repository: openstack/neutron-fwaas
+          ref: f6a36133a788697712733a69f10999fc2a9e2d6f # stable/2025.2
+
+      - uses: vexxhost/docker-atmosphere/.github/actions/checkout@5923a8fba3a98cf17e36583cc498d5e70a01c482 # main
+        with:
           repository: openstack/neutron-vpnaas
           ref: 7fbb8f3fa469d831beee216dae1c1829f0173be5 # stable/2025.2
 
@@ -57,11 +62,6 @@ jobs:
           repository: openstack/tap-as-a-service
           ref: 7b413b43f2cedb0a43056c4d6f89d413448050b2 # stable/2025.2
 
-      - uses: vexxhost/docker-atmosphere/.github/actions/checkout@5923a8fba3a98cf17e36583cc498d5e70a01c482 # main
-        with:
-          repository: openstack/neutron-fwaas
-          ref: f6a36133a788697712733a69f10999fc2a9e2d6f # stable/2025.2
-
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@main
         with:
           repository: vexxhost/atmosphere
@@ -74,12 +74,12 @@ jobs:
           build-contexts: |
             neutron=openstack/neutron
             neutron-dynamic-routing=openstack/neutron-dynamic-routing
+            neutron-fwaas=openstack/neutron-fwaas
             neutron-vpnaas=openstack/neutron-vpnaas
             networking-baremetal=openstack/networking-baremetal
             networking-generic-switch=openstack/networking-generic-switch
             neutron-policy-server=vexxhost/neutron-policy-server
             neutron-ovn-network-logging-parser=vexxhost/neutron-ovn-network-logging-parser
             tap-as-a-service=openstack/tap-as-a-service
-            neutron-fwaas=openstack/neutron-fwaas
             ovsinit-src=vexxhost/atmosphere/crates/ovsinit
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@5923a8fba3a98cf17e36583cc498d5e70a01c482 # main
         with:
           repository: openstack/neutron-fwaas
-          ref: f6a36133a788697712733a69f10999fc2a9e2d6f # stable/2025.2
+          ref: 8ba344faf2a36d6f20a75384af80c26e0342a1bc # stable/2025.2
 
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@5923a8fba3a98cf17e36583cc498d5e70a01c482 # main
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN \
   --mount=type=bind,from=networking-generic-switch,source=/,target=/src/networking-generic-switch,readwrite \
   --mount=type=bind,from=neutron-policy-server,source=/,target=/src/neutron-policy-server,readwrite \
   --mount=type=bind,from=neutron-ovn-network-logging-parser,source=/,target=/src/neutron-ovn-network-logging-parser,readwrite \
-  --mount=type=bind,from=tap-as-a-service,source=/,target=/src/tap-as-a-service,readwrite <<EOF bash -xe
+  --mount=type=bind,from=tap-as-a-service,source=/,target=/src/tap-as-a-service,readwrite \
+  --mount=type=bind,from=neutron-fwaas,source=/,target=/src/neutron-fwaas,readwrite <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/neutron \
@@ -26,6 +27,7 @@ uv pip install \
         /src/neutron-policy-server \
         /src/neutron-ovn-network-logging-parser \
         /src/tap-as-a-service \
+        /src/neutron-fwaas \
         pymemcache
 EOF
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,24 +10,24 @@ FROM ghcr.io/vexxhost/openstack-venv-builder:2025.2@sha256:7d1cc3aba4829555aa737
 RUN \
   --mount=type=bind,from=neutron,source=/,target=/src/neutron,readwrite \
   --mount=type=bind,from=neutron-dynamic-routing,source=/,target=/src/neutron-dynamic-routing,readwrite \
+  --mount=type=bind,from=neutron-fwaas,source=/,target=/src/neutron-fwaas,readwrite \
   --mount=type=bind,from=neutron-vpnaas,source=/,target=/src/neutron-vpnaas,readwrite \
   --mount=type=bind,from=networking-baremetal,source=/,target=/src/networking-baremetal,readwrite \
   --mount=type=bind,from=networking-generic-switch,source=/,target=/src/networking-generic-switch,readwrite \
   --mount=type=bind,from=neutron-policy-server,source=/,target=/src/neutron-policy-server,readwrite \
   --mount=type=bind,from=neutron-ovn-network-logging-parser,source=/,target=/src/neutron-ovn-network-logging-parser,readwrite \
-  --mount=type=bind,from=tap-as-a-service,source=/,target=/src/tap-as-a-service,readwrite \
-  --mount=type=bind,from=neutron-fwaas,source=/,target=/src/neutron-fwaas,readwrite <<EOF bash -xe
+  --mount=type=bind,from=tap-as-a-service,source=/,target=/src/tap-as-a-service,readwrite <<EOF bash -xe
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/neutron \
         /src/neutron-dynamic-routing \
+        /src/neutron-fwaas \
         /src/neutron-vpnaas \
         /src/networking-baremetal \
         /src/networking-generic-switch \
         /src/neutron-policy-server \
         /src/neutron-ovn-network-logging-parser \
         /src/tap-as-a-service \
-        /src/neutron-fwaas \
         pymemcache
 EOF
 


### PR DESCRIPTION
## Summary

Backport neutron-fwaas image support to `stable/2025.2` so the Neutron server image can include the FWaaS OVN firewall service driver for Paltel's Atmosphere 7.7.0 deployment.

## Changes

- Add `openstack/neutron-fwaas` to the stable/2025.2 build checkout list.
- Add `neutron-fwaas` as a Docker build context.
- Install `/src/neutron-fwaas` into the Neutron image alongside the other Neutron `-aas` projects.
- Keep FWaaS ordered before VPNaaS in the workflow and Dockerfile lists.

## Validation

- Ran `git diff --check`.